### PR TITLE
Add a new feature to re-process unprocessed students in bulk upload

### DIFF
--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Upload;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
@@ -70,6 +71,18 @@ class FileController extends Controller
 
 
         return redirect('/')->withSuccess('The file is uploaded, we will process and let you know by your email');
+    }
+
+    public function updateQueueWithUnprocessedFiles(Request $request, $id, $action){
+        if($action == 100){
+            DB::table('uploads')
+                ->where('id', $id)
+                ->update(['is_processed' => 0]);
+        }elseif ($action == 200) {
+            DB::table('uploads')
+                ->where('id', $id)
+                ->update(['is_processed' => 4]);
+        }
     }
 
 

--- a/app/Http/Controllers/FilesController.php
+++ b/app/Http/Controllers/FilesController.php
@@ -76,6 +76,23 @@ class FilesController extends Controller
                     return '<a href="/bulk-upload/download/'.$data->filename.'">'.$data->filename.'</a>';
                 }
 
+            })->editColumn('actions', function ($data) {
+
+                $nowTime = \Carbon\Carbon::now();
+                $to = \Carbon\Carbon::createFromFormat('Y-m-d H:s:i', $nowTime);
+                $from = \Carbon\Carbon::createFromFormat('Y-m-d H:s:i', $data->updated_at);
+
+                $diff_in_hours = $to->diffInHours($from);
+
+                if($diff_in_hours >= 2 && $data->is_processed == 3){
+                    return '<div><h6>Processing <span class="badge badge-success text-uppercase">Successful</span></h6></div>';
+                }else {
+                    return '
+                    <div class="btn-group">
+                            <button onclick="updateProcess('.($data->id).',100)" class="btn btn-danger text-uppercase">reprocess</button>
+                            <button onclick="updateProcess('.($data->id).',200)" class="btn btn-success text-uppercase">pause</button>
+                            </div>';
+                }
             })
             ->rawColumns(['filename','error'])
             ->make(true);

--- a/resources/views/displaydata.blade.php
+++ b/resources/views/displaydata.blade.php
@@ -4,42 +4,57 @@
     <div class="container">
         <div class="panel panel-default">
             <div class="container">
-                <table class="table table-bordered" id="table">
-                    <thead>
-                    <tr>
-                        <th>Id</th>
-                        <th>Original file</th>
-                        <th>Error file</th>
-                        <th>Insert Status</th>
-                        <th>Update Status</th>
-                        <th>Overall</th>
-                        <th>Uploaded at</th>
-                        <th>Last update</th>
-                        <th>Email Status</th>
-                    </tr>
-                    </thead>
-                </table>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-striped" id="table">
+                        <thead class="thead-dark">
+                        <tr>
+                            <th>Id</th>
+                            <th>Original file</th>
+                            <th>Error file</th>
+                            <th>Insert Status</th>
+                            <th>Update Status</th>
+                            <th>Overall</th>
+                            <th>Uploaded at</th>
+                            <th>Last update</th>
+                            <th>Email Status</th>
+                            <th>Actions</th>
+                        </tr>
+                        </thead>
+                    </table>
+                </div>
             </div>
-            <script>
-                $(function() {
-                    $('#table').DataTable({
-                        processing: false,
-                        serverSide: true,
-                        ajax: '{{ url('index') }}',
-                        columns: [
-                            { data: 'id', name: 'id' },
-                            { data: 'filename', name: 'filename' },
-                            { data: 'error', name: 'error' },
-                            { data: 'insert' , name: 'Insert Status'},
-                            { data: 'update' , name: 'Update Status'},
-                            { data: 'is_processed', name: 'Overall'},
-                            { data: 'created_at' , name: 'Uploaded at'},
-                            { data: 'updated_at' , name: 'Last update'},
-                            { data: 'is_email_sent' , name: 'Email Status'}
-                        ]
-                    });
-                });
-            </script>
         </div>
     </div>
+    <script>
+        $(function () {
+            $('#table').DataTable({
+                processing: false,
+                serverSide: true,
+                ajax: '{{ url('index') }}',
+                columns: [
+                    {data: 'id', name: 'id'},
+                    {data: 'filename', name: 'filename'},
+                    {data: 'error', name: 'error'},
+                    {data: 'insert', name: 'Insert Status'},
+                    {data: 'update', name: 'Update Status'},
+                    {data: 'is_processed', name: 'Overall'},
+                    {data: 'created_at', name: 'Uploaded at'},
+                    {data: 'updated_at', name: 'Last update'},
+                    {data: 'is_email_sent', name: 'Email Status'},
+                    {data: 'actions', name: 'actions'}
+                ]
+            });
+        });
+
+        function updateProcess($id, $action) {
+            var CSRF_TOKEN = $('meta[name="csrf-token"]').attr('content');
+            $.ajax({
+                url: '/updateUnprocessedFiles/'+$id+'/'+$action,
+                type: 'POST',
+                data: {_token: CSRF_TOKEN, id: $id, action: $action},
+                dataType: 'JSON'
+            }).done(location.reload());
+        }
+
+    </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::get('/', 'ImportExport@importExportView')->middleware('Role:PRINCIPAL');
 Route::get('downloadExcel', 'FileController@downloadTemplate');
 Route::post('importExcel', 'ImportExport@import');
 Route::post('exportExcel', 'ImportExport@export');
+Route::post('updateUnprocessedFiles/{id}/{action}', 'FileController@updateQueueWithUnprocessedFiles');
 
 //Auth::routes();
 Auth::routes(['register' => false]);


### PR DESCRIPTION
### **Goal**
Re-process the sheets of unprocessed students which are in the pending state in the bulk upload.

### **Solution**
Provide the user with an option where he/she can reprocess or pause the current process of the sheet using two buttons on the bulk upload history table (Last column: Action).
